### PR TITLE
Exceptions cause ClassLoader not to be collected and are thus swallowed

### DIFF
--- a/src/test/java/se/jiderhamn/JUnitClassloaderRunner.java
+++ b/src/test/java/se/jiderhamn/JUnitClassloaderRunner.java
@@ -93,7 +93,7 @@ public class JUnitClassloaderRunner extends BlockJUnit4ClassRunner {
         redefinedClass = null;
       }
       catch (Exception e) {
-        throw new RuntimeException(e);
+        throw new RuntimeException(e.getClass().getName() + ": " + e.getMessage());
       }
       finally {
         Thread.currentThread().setContextClassLoader(clBefore);


### PR DESCRIPTION
If you e.g. call

```
@Test
@Leaks(value = false)
public void triggerLeak() throws Exception {
    InputStream is = null;
    try {
        is = new FileInputStream("./app.truststore");
    } catch (Exception e) {
        System.out.println(e);
    } finally {
        if (is != null) {
            is.close();
        }
    }
}
```

it will throw a FileNotFoundException if the file does not exists. Therefore the Classloader loads the FileNotFoundException class. This in turn prevents the Classloader from being collected. This in turn hides fails the test and swallows the exception. I was hunting a bug for a few hours because of this :/
