### PR TITLE
Bring to base java 6 support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,22 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Custom for Visual Studio
+*.cs     diff=csharp
+*.sln    merge=union
+*.csproj merge=union
+*.vbproj merge=union
+*.fsproj merge=union
+*.dbproj merge=union
+
+# Standard to msysgit
+*.doc	 diff=astextplain
+*.DOC	 diff=astextplain
+*.docx diff=astextplain
+*.DOCX diff=astextplain
+*.dot  diff=astextplain
+*.DOT  diff=astextplain
+*.pdf  diff=astextplain
+*.PDF	 diff=astextplain
+*.rtf	 diff=astextplain
+*.RTF	 diff=astextplain

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 target
+.classpath
+.project
+.settings

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.sonatype.oss</groupId>
     <artifactId>oss-parent</artifactId>
-    <version>7</version>
+    <version>9</version>
   </parent>
   <groupId>se.jiderhamn</groupId>
   <artifactId>classloader-leak-prevention</artifactId>
@@ -34,6 +34,11 @@
     </developer>
   </developers>   
 
+  <properties>
+    <maven.compiler.source>1.6</maven.compiler.source>
+    <maven.compiler.target>1.6</maven.compiler.target>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>javax.servlet</groupId>
@@ -44,7 +49,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.10</version>
+      <version>4.11</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -57,7 +62,7 @@
     <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
-      <version>1.1.1</version>
+      <version>1.1.3</version>
       <scope>test</scope>
     </dependency>
     <!-- Validation API needed for testing leak -->
@@ -84,7 +89,7 @@
     <dependency>
       <groupId>commons-discovery</groupId>
       <artifactId>commons-discovery</artifactId>
-      <version>0.2</version>
+      <version>0.5</version>
       <scope>test</scope>
     </dependency>
     <!-- JDBC driver for DriverManager test -->
@@ -140,7 +145,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.1</version>
+            <version>1.5</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/src/main/java/se/jiderhamn/classloader/leak/prevention/ClassLoaderLeakPreventor.java
+++ b/src/main/java/se/jiderhamn/classloader/leak/prevention/ClassLoaderLeakPreventor.java
@@ -1062,7 +1062,6 @@ public class ClassLoaderLeakPreventor implements javax.servlet.ServletContextLis
     final Field ibmRunnable = findField(Thread.class, "runnable"); // IBM JRE
 
     for(Thread thread : getAllThreads()) {
-      @SuppressWarnings("RedundantCast") 
       final Runnable runnable = (oracleTarget != null) ? 
           (Runnable) getFieldValue(oracleTarget, thread) : // Sun/Oracle JRE  
           (Runnable) getFieldValue(ibmRunnable, thread);   // IBM JRE

--- a/src/test/java/se/jiderhamn/JUnitClassloaderRunner.java
+++ b/src/test/java/se/jiderhamn/JUnitClassloaderRunner.java
@@ -33,7 +33,7 @@ public class JUnitClassloaderRunner extends BlockJUnit4ClassRunner {
 
     return new SeparateClassLoaderInvokeMethod(method, test, preventorClass);
   }
-  
+
   private static class SeparateClassLoaderInvokeMethod extends InvokeMethod {
     
     /** The method to run for triggering potential leak, or verify non-leak */
@@ -54,7 +54,7 @@ public class JUnitClassloaderRunner extends BlockJUnit4ClassRunner {
     private SeparateClassLoaderInvokeMethod(FrameworkMethod testMethod, Object target) {
       this(testMethod, target, null);
     }
-    
+
     private SeparateClassLoaderInvokeMethod(FrameworkMethod testMethod, Object target, Class<? extends Runnable> preventorClass) {
       super(testMethod, target);
       originalMethod = testMethod.getMethod();
@@ -66,7 +66,6 @@ public class JUnitClassloaderRunner extends BlockJUnit4ClassRunner {
       this.preventorClass = preventorClass;
     }
 
-    @SuppressWarnings("UnusedAssignment")
     @Override
     public void evaluate() throws Throwable {
       final Class<?> junitClass = originalMethod.getDeclaringClass();
@@ -79,8 +78,8 @@ public class JUnitClassloaderRunner extends BlockJUnit4ClassRunner {
         Thread.currentThread().setContextClassLoader(myClassLoader);
         Class redefinedClass = myClassLoader.loadClass(junitClass.getName());
 
-  System.out.println("JUnit used " + junitClass.getClassLoader()); // TODO turn debugging on/off      
-  System.out.println("SeparateClassLoaderInvokeMethod used " + redefinedClass.getClassLoader()); // TODO turn debugging on/off
+        System.out.println("JUnit used " + junitClass.getClassLoader()); // TODO turn debugging on/off
+        System.out.println("SeparateClassLoaderInvokeMethod used " + redefinedClass.getClassLoader()); // TODO turn debugging on/off
 
         Method myMethod = redefinedClass.getDeclaredMethod(originalMethod.getName(), originalMethod.getParameterTypes());
         TestClass myTestClass = new TestClass(redefinedClass);

--- a/src/test/java/se/jiderhamn/RedefiningClassLoader.java
+++ b/src/test/java/se/jiderhamn/RedefiningClassLoader.java
@@ -4,18 +4,17 @@ import org.apache.bcel.classfile.JavaClass;
 
 /** Classloader that redefines classes even if existing in parent */
 class RedefiningClassLoader extends org.apache.bcel.util.ClassLoader {
-  
+
   /** Override parents default and include  */
   public static final String[] DEFAULT_IGNORED_PACKAGES = {
           "java.", "javax.", "sun.", "org.junit.", "junit."
   };
-  
+
   /** Set to non-null to indicate it should be ready for garbage collection */
-  @SuppressWarnings({"FieldCanBeLocal", "UnusedDeclaration"})
+  @SuppressWarnings("unused")
   private ZombieMarker zombieMarker = null;
-  
+
   private final String name;
-      
 
   RedefiningClassLoader(ClassLoader parent) {
     this(parent, null);

--- a/src/test/java/se/jiderhamn/classloader/leak/prevention/BeanELResolverTest.java
+++ b/src/test/java/se/jiderhamn/classloader/leak/prevention/BeanELResolverTest.java
@@ -29,7 +29,6 @@ public class BeanELResolverTest {
   }
   
   /** Bean for testing */
-  @SuppressWarnings("UnusedDeclaration")
   public static class Bean {
     private String foo;
 


### PR DESCRIPTION
Use java 6 as starting point rather than java 5.  POM was missing
setting to do this but contained code that was java 6 based.

Added standard git attributes.
Added missing git ignores.
Updated dependencies that do not affect leak detection.
Fix majority of warnings generated out of ClassLoaderLeakPreventor even
if most are <?>.