### PR TITLE
added ImageIO leak preventor and test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,13 +73,7 @@
       <version>4.2.0.Final</version>
       <scope>test</scope>
     </dependency>
-    <!-- ImageIO leak test -->
-    <dependency>
-      <groupId>com.twelvemonkeys.imageio</groupId>
-      <artifactId>imageio-tiff</artifactId>
-      <version>3.0.2</version>
-      <scope>test</scope>
-    </dependency>
+    <!-- Apache Axis 1.4 for leak test -->
     <dependency>
       <groupId>org.apache.axis</groupId>
       <artifactId>axis</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,13 @@
       <version>4.2.0.Final</version>
       <scope>test</scope>
     </dependency>
-    <!-- Apache Axis 1.4 for leak test -->
+    <!-- ImageIO leak test -->
+    <dependency>
+      <groupId>com.twelvemonkeys.imageio</groupId>
+      <artifactId>imageio-tiff</artifactId>
+      <version>3.0.2</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.apache.axis</groupId>
       <artifactId>axis</artifactId>

--- a/src/main/java/se/jiderhamn/classloader/leak/prevention/ClassLoaderLeakPreventor.java
+++ b/src/main/java/se/jiderhamn/classloader/leak/prevention/ClassLoaderLeakPreventor.java
@@ -737,35 +737,34 @@ public class ClassLoaderLeakPreventor implements javax.servlet.ServletContextLis
   
   /** Unregister ImageIO Service Provider loaded by the web application class loader */
   protected void deregisterIIOServiceProvider() {
-      IIORegistry registry = IIORegistry.getDefaultInstance();
-      Iterator<Class<?>> categories = registry.getCategories();
-      ServiceRegistry.Filter classLoaderFilter = new ServiceRegistry.Filter() {
-          @Override
-          public boolean filter(Object provider) {
-              //remove all service provider loaded by the current ClassLoader
-              boolean loadedByWebApp = getWebApplicationClassLoader().equals(provider.getClass().getClassLoader());
-              return loadedByWebApp;
-          }
-      };
-      while (categories.hasNext()) {
-          @SuppressWarnings("unchecked")
-          Class<IIOServiceProvider> category = (Class<IIOServiceProvider>) categories.next();
-          Iterator<IIOServiceProvider> serviceProviders = registry.<IIOServiceProvider> getServiceProviders(
-              category,
-              classLoaderFilter, true);
-          if (serviceProviders.hasNext()) {
-              //copy to list
-              List<IIOServiceProvider> serviceProviderList = new ArrayList<IIOServiceProvider>();
-              while (serviceProviders.hasNext()) {
-                  serviceProviderList.add(serviceProviders.next());
-              }
-              for (IIOServiceProvider serviceProvider : serviceProviderList) {
-                    warn("ImageIO " + category.getSimpleName() + " service provider deregistered: "
-                        + serviceProvider.getDescription(Locale.ROOT));
-                  registry.deregisterServiceProvider(serviceProvider);
-              }
-          }
+    IIORegistry registry = IIORegistry.getDefaultInstance();
+    Iterator<Class<?>> categories = registry.getCategories();
+    ServiceRegistry.Filter classLoaderFilter = new ServiceRegistry.Filter() {
+      @Override
+      public boolean filter(Object provider) {
+        //remove all service provider loaded by the current ClassLoader
+        return isLoadedInWebApplication(provider);
       }
+    };
+    while (categories.hasNext()) {
+      @SuppressWarnings("unchecked")
+      Class<IIOServiceProvider> category = (Class<IIOServiceProvider>) categories.next();
+      Iterator<IIOServiceProvider> serviceProviders = registry.<IIOServiceProvider> getServiceProviders(
+        category,
+        classLoaderFilter, true);
+      if (serviceProviders.hasNext()) {
+        //copy to list
+        List<IIOServiceProvider> serviceProviderList = new ArrayList<IIOServiceProvider>();
+        while (serviceProviders.hasNext()) {
+          serviceProviderList.add(serviceProviders.next());
+        }
+        for (IIOServiceProvider serviceProvider : serviceProviderList) {
+          warn("ImageIO " + category.getSimpleName() + " service provider deregistered: "
+            + serviceProvider.getDescription(Locale.ROOT));
+          registry.deregisterServiceProvider(serviceProvider);
+        }
+      }
+    }
   }
 
 /** Deregister JDBC drivers loaded by web app classloader */

--- a/src/main/java/se/jiderhamn/classloader/leak/prevention/ClassLoaderLeakPreventor.java
+++ b/src/main/java/se/jiderhamn/classloader/leak/prevention/ClassLoaderLeakPreventor.java
@@ -30,6 +30,10 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.*;
 import java.util.concurrent.ThreadPoolExecutor;
+
+import javax.imageio.spi.IIORegistry;
+import javax.imageio.spi.IIOServiceProvider;
+import javax.imageio.spi.ServiceRegistry;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 import javax.servlet.ServletContext;
@@ -638,6 +642,9 @@ public class ClassLoaderLeakPreventor implements javax.servlet.ServletContextLis
     
     // Force the execution of the cleanup code for JURT; see https://issues.apache.org/ooo/show_bug.cgi?id=122517
     forceStartOpenOfficeJurtCleanup();
+    
+    // clear ImageIO registry
+    deregisterIIOServiceProvider();
 
     ////////////////////
     // Fix generic leaks
@@ -728,7 +735,40 @@ public class ClassLoaderLeakPreventor implements javax.servlet.ServletContextLis
   // Fix generic leaks
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   
-  /** Deregister JDBC drivers loaded by web app classloader */
+  /** Unregister ImageIO Service Provider loaded by the web application class loader */
+  protected void deregisterIIOServiceProvider() {
+      IIORegistry registry = IIORegistry.getDefaultInstance();
+      Iterator<Class<?>> categories = registry.getCategories();
+      ServiceRegistry.Filter classLoaderFilter = new ServiceRegistry.Filter() {
+          @Override
+          public boolean filter(Object provider) {
+              //remove all service provider loaded by the current ClassLoader
+              boolean loadedByWebApp = getWebApplicationClassLoader().equals(provider.getClass().getClassLoader());
+              return loadedByWebApp;
+          }
+      };
+      while (categories.hasNext()) {
+          @SuppressWarnings("unchecked")
+          Class<IIOServiceProvider> category = (Class<IIOServiceProvider>) categories.next();
+          Iterator<IIOServiceProvider> serviceProviders = registry.<IIOServiceProvider> getServiceProviders(
+              category,
+              classLoaderFilter, true);
+          if (serviceProviders.hasNext()) {
+              //copy to list
+              List<IIOServiceProvider> serviceProviderList = new ArrayList<IIOServiceProvider>();
+              while (serviceProviders.hasNext()) {
+                  serviceProviderList.add(serviceProviders.next());
+              }
+              for (IIOServiceProvider serviceProvider : serviceProviderList) {
+                    warn("ImageIO " + category.getSimpleName() + " service provider deregistered: "
+                        + serviceProvider.getDescription(Locale.ROOT));
+                  registry.deregisterServiceProvider(serviceProvider);
+              }
+          }
+      }
+  }
+
+/** Deregister JDBC drivers loaded by web app classloader */
   public void deregisterJdbcDrivers() {
     final List<Driver> driversToDeregister = new ArrayList<Driver>();
     final Enumeration<Driver> allDrivers = DriverManager.getDrivers();

--- a/src/test/java/se/jiderhamn/classloader/leak/prevention/ImageIOMockImageInputStreamSPI.java
+++ b/src/test/java/se/jiderhamn/classloader/leak/prevention/ImageIOMockImageInputStreamSPI.java
@@ -1,0 +1,22 @@
+package se.jiderhamn.classloader.leak.prevention;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Locale;
+
+import javax.imageio.spi.ImageInputStreamSpi;
+import javax.imageio.stream.ImageInputStream;
+
+public class ImageIOMockImageInputStreamSPI extends ImageInputStreamSpi {
+
+    @Override
+    public ImageInputStream createInputStreamInstance(Object input, boolean useCache, File cacheDir) throws IOException {
+        throw new IllegalArgumentException("mock class");
+    }
+
+    @Override
+    public String getDescription(Locale locale) {
+        return "mock ImageInputStream provider";
+    }
+
+}

--- a/src/test/java/se/jiderhamn/classloader/leak/prevention/ImageIOTest.java
+++ b/src/test/java/se/jiderhamn/classloader/leak/prevention/ImageIOTest.java
@@ -1,0 +1,34 @@
+package se.jiderhamn.classloader.leak.prevention;
+
+import javax.imageio.ImageIO;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import se.jiderhamn.JUnitClassloaderRunner;
+import se.jiderhamn.LeakPreventor;
+
+/**
+ * @author Thomas Scheffler
+ */
+@RunWith(JUnitClassloaderRunner.class)
+@LeakPreventor(ImageIOTest.Prevent.class)
+public class ImageIOTest {
+  
+  @Test
+  public void triggerImageIOLeak() throws Exception {
+    ImageIO.scanForPlugins();
+  }
+  
+  public static class Prevent implements Runnable {
+    public void run() {
+      new ClassLoaderLeakPreventor() {
+        { // Initializer / "Constructor"
+          deregisterIIOServiceProvider();
+        }
+      };
+    }
+
+  }
+
+}

--- a/src/test/resources/META-INF/services/javax.imageio.spi.ImageInputStreamSpi
+++ b/src/test/resources/META-INF/services/javax.imageio.spi.ImageInputStreamSpi
@@ -1,0 +1,1 @@
+se.jiderhamn.classloader.leak.prevention.ImageIOMockImageInputStreamSPI


### PR DESCRIPTION
This leak preventor removes any ImageIO service provider registered via `ImageIO.scanPlugins()`.