### PR TITLE
Add cleanup for JDK-8151486: Class.forName causes memory leak

### DIFF
--- a/classloader-leak-prevention/classloader-leak-prevention-core/src/main/java/se/jiderhamn/classloader/leak/prevention/ClassLoaderLeakPreventorFactory.java
+++ b/classloader-leak-prevention/classloader-leak-prevention-core/src/main/java/se/jiderhamn/classloader/leak/prevention/ClassLoaderLeakPreventorFactory.java
@@ -120,6 +120,7 @@ public class ClassLoaderLeakPreventorFactory {
     this.addCleanUp(new ThreadLocalCleanUp()); // This must be done after threads have been stopped, or new ThreadLocals may be added by those threads
     this.addCleanUp(new KeepAliveTimerCacheCleanUp());
     this.addCleanUp(new ResourceBundleCleanUp());
+    this.addCleanUp(new JDK8151486CleanUp());
     this.addCleanUp(new ApacheCommonsLoggingCleanUp()); // Do this last, in case other shutdown procedures want to log something.
     
   }

--- a/classloader-leak-prevention/classloader-leak-prevention-core/src/main/java/se/jiderhamn/classloader/leak/prevention/cleanup/JDK8151486CleanUp.java
+++ b/classloader-leak-prevention/classloader-leak-prevention-core/src/main/java/se/jiderhamn/classloader/leak/prevention/cleanup/JDK8151486CleanUp.java
@@ -1,0 +1,30 @@
+package se.jiderhamn.classloader.leak.prevention.cleanup;
+
+import se.jiderhamn.classloader.leak.prevention.ClassLoaderLeakPreventor;
+import se.jiderhamn.classloader.leak.prevention.ClassLoaderPreMortemCleanUp;
+
+import java.lang.reflect.Field;
+import java.util.Set;
+
+/**
+ * Clear the "domains" field of the parent ClassLoader.
+ *
+ * See <a href="https://bugs.openjdk.java.net/browse/JDK-8151486">JDK-8151486</a>
+ */
+public class JDK8151486CleanUp implements ClassLoaderPreMortemCleanUp {
+    @Override
+    public void cleanUp(ClassLoaderLeakPreventor preventor) {
+        Field field = preventor.findField(ClassLoader.class, "domains");
+        if (field == null) {
+            // field only exists in JDK versions [8u25, 9u140)
+            return;
+        }
+
+        for (ClassLoader cl = preventor.getClassLoader().getParent(); cl != null; cl = cl.getParent()) {
+            Set<?> domains = preventor.getFieldValue(field, cl);
+            if (domains != null) {
+                domains.clear();
+            }
+        }
+    }
+}

--- a/classloader-leak-prevention/classloader-leak-prevention-core/src/test/java/se/jiderhamn/classloader/leak/prevention/cleanup/JDK8151486CleanUpTest.java
+++ b/classloader-leak-prevention/classloader-leak-prevention-core/src/test/java/se/jiderhamn/classloader/leak/prevention/cleanup/JDK8151486CleanUpTest.java
@@ -1,0 +1,25 @@
+package se.jiderhamn.classloader.leak.prevention.cleanup;
+
+import org.junit.Ignore;
+
+import java.security.Permission;
+
+/**
+ * Test case for {@link JDK8151486CleanUp}
+ */
+@Ignore
+public class JDK8151486CleanUpTest extends ClassLoaderPreMortemCleanUpTestBase<JDK8151486CleanUp> {
+  @Override
+  protected void triggerLeak() throws Exception {
+    System.setSecurityManager(new SecurityManager() {
+      @Override
+      public void checkPermission(final Permission perm) {
+      }
+    });
+
+    Class.forName("java.lang.String", false, ClassLoader.getSystemClassLoader());
+
+    // leaving the security manager will cause a leak, but not the one we're testing for
+    System.setSecurityManager(null);
+  }
+}


### PR DESCRIPTION
https://bugs.openjdk.java.net/browse/JDK-8151486

This bug affects JDK versions [8u25, 9u140). A parent classloader holds references to all child classloaders and never removes them.

Here's an example showing my classloader rooted:
```
Class Name                                                                                | Ref. Objects | Shallow Heap | Ref. Shallow Heap | Retained Heap
------------------------------------------------------------------------------------------------------------------------------------------------------------
java.lang.Thread @ 0x795550000  Signal Dispatcher Thread                                  |            3 |          120 |               336 |           256
'- contextClassLoader sun.misc.Launcher$AppClassLoader @ 0x79555d710                      |            3 |           88 |               336 |     1,319,440
   '- domains java.util.Collections$SynchronizedSet @ 0x795683330                         |            3 |           24 |               336 |           296
      '- c java.util.HashSet @ 0x795699a80                                                |            3 |           16 |               336 |           272
         '- map java.util.HashMap @ 0x795687218                                           |            3 |           48 |               336 |           256
            '- table java.util.HashMap$Node[16] @ 0x7956921b0                             |            3 |           80 |               336 |           208
               |- [14] java.util.HashMap$Node @ 0x7a086e2d8                               |            1 |           32 |               112 |            32
               |  '- key java.security.ProtectionDomain @ 0x7a0577720                     |            1 |           40 |               112 |           744
               |     '- classloader sbt.classpath.ClasspathUtilities$$anon$1 @ 0x79b81f140|            1 |          112 |               112 |     5,285,688
               |- [12] java.util.HashMap$Node @ 0x79ccce950                               |            1 |           32 |               112 |            32
               |  '- key java.security.ProtectionDomain @ 0x79cc9a680                     |            1 |           40 |               112 |           744
               |     '- classloader sbt.classpath.ClasspathUtilities$$anon$1 @ 0x79b81e7e0|            1 |          112 |               112 |    16,203,384
               |- [10] java.util.HashMap$Node @ 0x79d659eb8                               |            1 |           32 |               112 |            32
               |  '- key java.security.ProtectionDomain @ 0x79d9bf658                     |            1 |           40 |               112 |           744
               |     '- classloader sbt.classpath.ClasspathUtilities$$anon$1 @ 0x79b81f050|            1 |          112 |               112 |     8,391,024
               '- Total: 3 entries                                                        |              |              |                   |              
------------------------------------------------------------------------------------------------------------------------------------------------------------
```