### PR TITLE
Add pre-initiator for OGLRenderQueue

### DIFF
--- a/classloader-leak-prevention/classloader-leak-prevention-core/src/main/java/se/jiderhamn/classloader/leak/prevention/ClassLoaderLeakPreventorFactory.java
+++ b/classloader-leak-prevention/classloader-leak-prevention-core/src/main/java/se/jiderhamn/classloader/leak/prevention/ClassLoaderLeakPreventorFactory.java
@@ -82,6 +82,7 @@ public class ClassLoaderLeakPreventorFactory {
     // Load Sun specific classes that may cause leaks
     this.addPreInitiator(new LdapPoolManagerInitiator());
     this.addPreInitiator(new Java2dDisposerInitiator());
+    this.addPreInitiator(new Java2dRenderQueueInitiator());
     this.addPreInitiator(new SunGCInitiator());
     this.addPreInitiator(new OracleJdbcThreadInitiator());
 

--- a/classloader-leak-prevention/classloader-leak-prevention-core/src/main/java/se/jiderhamn/classloader/leak/prevention/preinit/Java2dRenderQueueInitiator.java
+++ b/classloader-leak-prevention/classloader-leak-prevention-core/src/main/java/se/jiderhamn/classloader/leak/prevention/preinit/Java2dRenderQueueInitiator.java
@@ -1,0 +1,23 @@
+package se.jiderhamn.classloader.leak.prevention.preinit;
+
+import se.jiderhamn.classloader.leak.prevention.ClassLoaderLeakPreventor;
+import se.jiderhamn.classloader.leak.prevention.PreClassLoaderInitiator;
+
+import java.lang.reflect.Method;
+
+/**
+ * Using the class sun.java2d.opengl.OGLRenderQueue will spawn a new QueueFlusher thread with the same contextClassLoader.
+ */
+public class Java2dRenderQueueInitiator implements PreClassLoaderInitiator {
+    @Override
+    public void doOutsideClassLoader(ClassLoaderLeakPreventor preventor) {
+        try {
+            Method getInstance = preventor.findMethod("sun.java2d.opengl.OGLRenderQueue", "getInstance");
+            if (getInstance != null) {
+                getInstance.invoke(null);
+            }
+        } catch (Throwable e) {
+            preventor.warn(e);
+        }
+    }
+}

--- a/classloader-leak-prevention/classloader-leak-prevention-core/src/test/java/se/jiderhamn/classloader/leak/prevention/preinit/Java2dRenderQueueInitiatorTest.java
+++ b/classloader-leak-prevention/classloader-leak-prevention-core/src/test/java/se/jiderhamn/classloader/leak/prevention/preinit/Java2dRenderQueueInitiatorTest.java
@@ -1,0 +1,7 @@
+package se.jiderhamn.classloader.leak.prevention.preinit;
+
+/**
+ * Test cases for {@link Java2dRenderQueueInitiator}
+ */
+public class Java2dRenderQueueInitiatorTest extends PreClassLoaderInitiatorTestBase<Java2dRenderQueueInitiator> {
+}


### PR DESCRIPTION
`OGLRenderQueue` starts a thread which leaks its context class loader: http://www.docjar.com/html/api/sun/java2d/opengl/OGLRenderQueue.java.html

On my machine you can trigger this by calling `java.awt.GraphicsEnvironment.getLocalGraphicsEnvironment()`.

Example of a classloader being rooted:
```
Class Name                                                                                                          | Ref. Objects | Shallow Heap | Ref. Shallow Heap | Retained Heap
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
sun.java2d.opengl.OGLRenderQueue$QueueFlusher @ 0x79d53fb78  Java2D Queue Flusher Busy Monitor, Native Stack, Thread|            1 |          136 |                 8 |           720
'- contextClassLoader sbt.classpath.ClasspathFilter @ 0x79d019370                                                   |            1 |           80 |                 8 |        13,072
   '- parent, parent sbt.classpath.ClasspathUtilities$$anon$1 @ 0x79cfbf5a0                                         |            1 |          112 |                 8 |    17,747,080
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```
