### PR TITLE
JDK 11: Remove JavaDoc Links

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: java
 sudo: false
 jdk:
   - oraclejdk8
+  - openjdk11
 
 # Uncomment to upload heapdumps to S3 bucket; https://docs.travis-ci.com/user/uploading-artifacts/
 #addons:

--- a/classloader-leak-prevention/classloader-leak-prevention-core/src/main/java/se/jiderhamn/classloader/leak/prevention/ReplaceDOMNormalizerSerializerAbortException.java
+++ b/classloader-leak-prevention/classloader-leak-prevention-core/src/main/java/se/jiderhamn/classloader/leak/prevention/ReplaceDOMNormalizerSerializerAbortException.java
@@ -10,8 +10,8 @@ import java.lang.reflect.Field;
  *   Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
  *   DOMImplementationLS implementation = (DOMImplementationLS)document.getImplementation();
  *   implementation.createLSSerializer().writeToString(document);
- * </code> may trigger leaks caused by the static fields {@link com.sun.org.apache.xerces.internal.dom.DOMNormalizer#abort} and
- * {@link com.sun.org.apache.xml.internal.serialize.DOMSerializerImpl#abort} respectively keeping stacktraces/backtraces
+ * </code> may trigger leaks caused by the static fields "com.sun.org.apache.xerces.internal.dom.DOMNormalizer#abort" and
+ * "com.sun.org.apache.xml.internal.serialize.DOMSerializerImpl#abort" respectively keeping stacktraces/backtraces
  * that may include references to classes loaded by our web application.
  * 
  * Since the {@link java.lang.Throwable#backtrace} itself cannot be accessed via reflection (see 

--- a/classloader-leak-prevention/classloader-leak-prevention-core/src/main/java/se/jiderhamn/classloader/leak/prevention/cleanup/X509TrustManagerImplUnparseableExtensionCleanUp.java
+++ b/classloader-leak-prevention/classloader-leak-prevention-core/src/main/java/se/jiderhamn/classloader/leak/prevention/cleanup/X509TrustManagerImplUnparseableExtensionCleanUp.java
@@ -11,8 +11,8 @@ import se.jiderhamn.classloader.leak.prevention.ClassLoaderLeakPreventor;
 import se.jiderhamn.classloader.leak.prevention.ClassLoaderPreMortemCleanUp;
 
 /**
- * {@link sun.security.ssl.X509TrustManagerImpl} keeps a list set of trusted certs, which may include 
- * {@link sun.security.x509.UnparseableExtension} that in turn may include an {@link Exception} with a backtrace
+ * "sun.security.ssl.X509TrustManagerImpl" keeps a list set of trusted certs, which may include 
+ * "sun.security.x509.UnparseableExtension" that in turn may include an {@link Exception} with a backtrace
  * with references to the classloader that we want to protect 
  * @author Mattias Jiderhamn
  */

--- a/classloader-leak-prevention/classloader-leak-prevention-core/src/main/java/se/jiderhamn/classloader/leak/prevention/preinit/SunAwtAppContextInitiator.java
+++ b/classloader-leak-prevention/classloader-leak-prevention-core/src/main/java/se/jiderhamn/classloader/leak/prevention/preinit/SunAwtAppContextInitiator.java
@@ -6,8 +6,8 @@ import se.jiderhamn.classloader.leak.prevention.ClassLoaderLeakPreventor;
 import se.jiderhamn.classloader.leak.prevention.PreClassLoaderInitiator;
 
 /**
- * There will be a strong reference from {@link sun.awt.AppContext#contextClassLoader} to the classloader of the calls
- * to {@link sun.awt.AppContext#getAppContext()}. Avoid leak by forcing initialization using system classloader. 
+ * There will be a strong reference from "sun.awt.AppContext#contextClassLoader" to the classloader of the calls
+ * to "sun.awt.AppContext#getAppContext()". Avoid leak by forcing initialization using system classloader. 
  * Note that Google Web Toolkit (GWT) will trigger this leak via its use of javax.imageio.
  * 
  * See http://java.jiderhamn.se/2012/02/26/classloader-leaks-v-common-mistakes-and-known-offenders/

--- a/classloader-leak-prevention/classloader-leak-prevention-core/src/test/java/se/jiderhamn/classloader/leak/prevention/cleanup/MXBeanNotificationListenersCleanUp_ListenerWrapperTest.java
+++ b/classloader-leak-prevention/classloader-leak-prevention-core/src/test/java/se/jiderhamn/classloader/leak/prevention/cleanup/MXBeanNotificationListenersCleanUp_ListenerWrapperTest.java
@@ -5,10 +5,8 @@ import java.lang.reflect.Constructor;
 import javax.management.NotificationEmitter;
 import javax.management.NotificationListener;
 
-import com.sun.jmx.interceptor.DefaultMBeanServerInterceptor;
-
 /**
- * Test case for {@link MXBeanNotificationListenersCleanUp} when {@link DefaultMBeanServerInterceptor.ListenerWrapper}
+ * Test case for {@link MXBeanNotificationListenersCleanUp} when "com.sun.jmx.interceptor.DefaultMBeanServerInterceptor$ListenerWrapper"
  * is used.
  * @author Mattias Jiderhamn
  */


### PR DESCRIPTION
Hello @mjiderhamn,

since the first PR I've opened for Java 11 compatibility (#87) looks really cluttered, with multiple commits to the same file that sometimes revert each other, I'm splitting the changes into smaller PRs.

Here, I've removed the links to some packages in some JavaDoc comments, because these packages cannot be accessed directly anymore in with Java 11.