### PR TITLE
JDK 11: JceSecurityCleanupTest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: java
 sudo: false
 jdk:
   - oraclejdk8
+  - openjdk11
 
 # Uncomment to upload heapdumps to S3 bucket; https://docs.travis-ci.com/user/uploading-artifacts/
 #addons:

--- a/classloader-leak-prevention/classloader-leak-prevention-core/src/test/java/se/jiderhamn/classloader/leak/prevention/cleanup/JceSecurityCleanUpTest.java
+++ b/classloader-leak-prevention/classloader-leak-prevention-core/src/test/java/se/jiderhamn/classloader/leak/prevention/cleanup/JceSecurityCleanUpTest.java
@@ -16,7 +16,10 @@ public class JceSecurityCleanUpTest extends ClassLoaderPreMortemCleanUpTestBase<
       MyProvider myProvider = new MyProvider("foo", 1.0, "bar");
       javax.crypto.Mac.getInstance("baz", myProvider);
     }
-    catch (SecurityException | NoSuchAlgorithmException e) { // CS:IGNORE
+    catch (SecurityException e) { // CS:IGNORE
+      // Leak is triggered despite an exception being thrown
+    }
+    catch (NoSuchAlgorithmException e) { // CS:IGNORE
       // Leak is triggered despite an exception being thrown
     }
   }

--- a/classloader-leak-prevention/classloader-leak-prevention-core/src/test/java/se/jiderhamn/classloader/leak/prevention/cleanup/JceSecurityCleanUpTest.java
+++ b/classloader-leak-prevention/classloader-leak-prevention-core/src/test/java/se/jiderhamn/classloader/leak/prevention/cleanup/JceSecurityCleanUpTest.java
@@ -1,5 +1,6 @@
 package se.jiderhamn.classloader.leak.prevention.cleanup;
 
+import java.security.NoSuchAlgorithmException;
 import java.security.Provider;
 
 /**
@@ -16,6 +17,9 @@ public class JceSecurityCleanUpTest extends ClassLoaderPreMortemCleanUpTestBase<
       javax.crypto.Mac.getInstance("baz", myProvider);
     }
     catch (SecurityException e) { // CS:IGNORE
+    }
+    catch (NoSuchAlgorithmException e) {
+      // Custom providers seem to work different in Java 11, this still triggers the leak, even if we get this exception
     }
   }
   

--- a/classloader-leak-prevention/classloader-leak-prevention-core/src/test/java/se/jiderhamn/classloader/leak/prevention/cleanup/JceSecurityCleanUpTest.java
+++ b/classloader-leak-prevention/classloader-leak-prevention-core/src/test/java/se/jiderhamn/classloader/leak/prevention/cleanup/JceSecurityCleanUpTest.java
@@ -16,10 +16,8 @@ public class JceSecurityCleanUpTest extends ClassLoaderPreMortemCleanUpTestBase<
       MyProvider myProvider = new MyProvider("foo", 1.0, "bar");
       javax.crypto.Mac.getInstance("baz", myProvider);
     }
-    catch (SecurityException e) { // CS:IGNORE
-    }
-    catch (NoSuchAlgorithmException e) {
-      // Custom providers seem to work different in Java 11, this still triggers the leak, even if we get this exception
+    catch (SecurityException | NoSuchAlgorithmException e) { // CS:IGNORE
+      // Leak is triggered despite an exception being thrown
     }
   }
   


### PR DESCRIPTION
Hello @mjiderhamn,

since the first PR I've opened for Java 11 compatibility (#87) looks really cluttered, with multiple commits to the same file that sometimes revert each other, I'm splitting the changes into smaller PRs.

The `JceSecurityCleanupTest` fails with Java 11, because a `NoSuchAlgorithmException` gets thrown. However, this still triggers the leak, so we just catch the Exception and ignore it.