### PR TITLE
JDK 11: MoxyCleanupTest

### DIFF
--- a/classloader-leak-prevention/classloader-leak-prevention-core/pom.xml
+++ b/classloader-leak-prevention/classloader-leak-prevention-core/pom.xml
@@ -134,6 +134,32 @@
       <scope>test</scope>
     </dependency>
     -->
+
+    <!-- Internal APIs that have been removed from the JDK in java 11. Used for MoxyCleanUpTest -->
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.2.11</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+      <version>2.2.11</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <version>2.2.11</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>javax.activation</groupId>
+      <artifactId>activation</artifactId>
+      <version>1.1.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <!-- Create artifact (jar) with test classes https://maven.apache.org/guides/mini/guide-attached-tests.html -->

--- a/classloader-leak-prevention/classloader-leak-prevention-core/src/test/java/se/jiderhamn/classloader/leak/prevention/cleanup/MoxyCleanUpTest.java
+++ b/classloader-leak-prevention/classloader-leak-prevention-core/src/test/java/se/jiderhamn/classloader/leak/prevention/cleanup/MoxyCleanUpTest.java
@@ -17,7 +17,13 @@ public class MoxyCleanUpTest extends ClassLoaderPreMortemCleanUpTestBase<MoxyCle
     // Class.forName("org.eclipse.persistence.jaxb.compiler.Property", true, leakSafeCL);
     Class.forName("org.eclipse.persistence.jaxb.compiler.CompilerHelper", true, leakSafeCL);
     
-    CompilerHelper.getXmlBindingsModelContext();
+    try {
+      CompilerHelper.getXmlBindingsModelContext();
+    }
+    catch(IllegalAccessError e) {
+      // CompilerHelper.getXmlBindingsModelContext() tries to load some internal classes that 
+      // cannot be loaded anymore with java versions > 8 (Jigsaw)
+    }
     
     // This prevention needs to be run in addition
     new ResourceBundleCleanUp().cleanUp(getClassLoaderLeakPreventor());


### PR DESCRIPTION
Hello @mjiderhamn,

since the first PR I've opened for Java 11 compatibility (#87) looks really cluttered, with multiple commits to the same file that sometimes revert each other, I'm splitting the changes into smaller PRs.

With Java 11, some Java APIs, like `javax.xml.bind` or `jaxb` have been removed from the JDK. These APIs are used by the `MoxyCleanupTest` to trigger the leak, so we can just add them as a dependency to use while running tests.