### PR TITLE
JDK 11:  SAAJEnvelopeFactoryParserPoolCleanUp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: java
 sudo: false
 jdk:
   - oraclejdk8
+  - openjdk11
 
 # Uncomment to upload heapdumps to S3 bucket; https://docs.travis-ci.com/user/uploading-artifacts/
 #addons:

--- a/classloader-leak-prevention/classloader-leak-prevention-core/pom.xml
+++ b/classloader-leak-prevention/classloader-leak-prevention-core/pom.xml
@@ -141,6 +141,7 @@
       <groupId>com.sun.xml.messaging.saaj</groupId>
       <artifactId>saaj-impl</artifactId>
       <version>1.4.0</version>
+      <scope>provided</scope>
     </dependency>
     
   </dependencies>

--- a/classloader-leak-prevention/classloader-leak-prevention-core/pom.xml
+++ b/classloader-leak-prevention/classloader-leak-prevention-core/pom.xml
@@ -134,6 +134,15 @@
       <scope>test</scope>
     </dependency>
     -->
+    
+    <!-- Internal APIs that have been removed from the JDK in java 11. -->
+    <!-- Used for testing SAAJEnvelopeFactoryParserPoolCleanUp. -->
+    <dependency>
+      <groupId>com.sun.xml.messaging.saaj</groupId>
+      <artifactId>saaj-impl</artifactId>
+      <version>1.4.0</version>
+    </dependency>
+    
   </dependencies>
 
   <!-- Create artifact (jar) with test classes https://maven.apache.org/guides/mini/guide-attached-tests.html -->

--- a/classloader-leak-prevention/classloader-leak-prevention-core/src/main/java/se/jiderhamn/classloader/leak/prevention/cleanup/SAAJEnvelopeFactoryParserPoolCleanUp.java
+++ b/classloader-leak-prevention/classloader-leak-prevention-core/src/main/java/se/jiderhamn/classloader/leak/prevention/cleanup/SAAJEnvelopeFactoryParserPoolCleanUp.java
@@ -19,7 +19,7 @@ public class SAAJEnvelopeFactoryParserPoolCleanUp implements ClassLoaderPreMorte
         parserPool = preventor.getStaticFieldValue("com.sun.xml.internal.messaging.saaj.soap.EnvelopeFactory",
         "parserPool");
     if(parserPool == null) {
-      // We are running JDK 11, so the SAAJ APIs are not available in the JDK anymore. -> Use the maven dependency
+      // Try the package for the maven dependency if the internal one is not available
       parserPool = preventor.getStaticFieldValue("com.sun.xml.messaging.saaj.soap.EnvelopeFactory",
           "parserPool");
     }

--- a/classloader-leak-prevention/classloader-leak-prevention-core/src/main/java/se/jiderhamn/classloader/leak/prevention/cleanup/SAAJEnvelopeFactoryParserPoolCleanUp.java
+++ b/classloader-leak-prevention/classloader-leak-prevention-core/src/main/java/se/jiderhamn/classloader/leak/prevention/cleanup/SAAJEnvelopeFactoryParserPoolCleanUp.java
@@ -15,9 +15,15 @@ import se.jiderhamn.classloader.leak.prevention.ClassLoaderPreMortemCleanUp;
 public class SAAJEnvelopeFactoryParserPoolCleanUp implements ClassLoaderPreMortemCleanUp {
   @Override
   public void cleanUp(ClassLoaderLeakPreventor preventor) {
-    final Object /*com.sun.xml.internal.messaging.saaj.soap.ContextClassloaderLocal*/
+    Object /*com.sun.xml.internal.messaging.saaj.soap.ContextClassloaderLocal*/
         parserPool = preventor.getStaticFieldValue("com.sun.xml.internal.messaging.saaj.soap.EnvelopeFactory",
         "parserPool");
+    if(parserPool == null) {
+      // We are running JDK 11, so the SAAJ APIs are not available in the JDK anymore. -> Use the maven dependency
+      parserPool = preventor.getStaticFieldValue("com.sun.xml.messaging.saaj.soap.EnvelopeFactory",
+          "parserPool");
+    }
+    
     if(parserPool != null) {
       final Field CACHE = preventor.findField(parserPool.getClass().getSuperclass(), "CACHE");
       if(CACHE != null) {

--- a/classloader-leak-prevention/classloader-leak-prevention-core/src/main/java/se/jiderhamn/classloader/leak/prevention/cleanup/SAAJEnvelopeFactoryParserPoolCleanUp.java
+++ b/classloader-leak-prevention/classloader-leak-prevention-core/src/main/java/se/jiderhamn/classloader/leak/prevention/cleanup/SAAJEnvelopeFactoryParserPoolCleanUp.java
@@ -15,14 +15,14 @@ import se.jiderhamn.classloader.leak.prevention.ClassLoaderPreMortemCleanUp;
 public class SAAJEnvelopeFactoryParserPoolCleanUp implements ClassLoaderPreMortemCleanUp {
   @Override
   public void cleanUp(ClassLoaderLeakPreventor preventor) {
-    Object /*com.sun.xml.internal.messaging.saaj.soap.ContextClassloaderLocal*/
-        parserPool = preventor.getStaticFieldValue("com.sun.xml.internal.messaging.saaj.soap.EnvelopeFactory",
-        "parserPool");
-    if(parserPool == null) {
-      // Try the package for the maven dependency if the internal one is not available
-      parserPool = preventor.getStaticFieldValue("com.sun.xml.messaging.saaj.soap.EnvelopeFactory",
-          "parserPool");
-    }
+    // Internal class from the JDK (Removed in JDK11)
+    cleanupWithFactoryClass(preventor, preventor.findClass("com.sun.xml.internal.messaging.saaj.soap.EnvelopeFactory"));
+    // Maven dependency
+    cleanupWithFactoryClass(preventor, preventor.findClass("com.sun.xml.messaging.saaj.soap.EnvelopeFactory"));
+  }
+
+  private void cleanupWithFactoryClass(final ClassLoaderLeakPreventor preventor, Class<?> factoryClass) {
+    final Object parserPool = preventor.getStaticFieldValue(factoryClass, "parserPool");
     
     if(parserPool != null) {
       final Field CACHE = preventor.findField(parserPool.getClass().getSuperclass(), "CACHE");

--- a/classloader-leak-prevention/classloader-leak-prevention-core/src/test/java/se/jiderhamn/classloader/leak/prevention/cleanup/SAAJEnvelopeFactoryParserPoolCleanUpTest.java
+++ b/classloader-leak-prevention/classloader-leak-prevention-core/src/test/java/se/jiderhamn/classloader/leak/prevention/cleanup/SAAJEnvelopeFactoryParserPoolCleanUpTest.java
@@ -13,7 +13,7 @@ import static org.junit.Assert.assertNotNull;
  */
 public class SAAJEnvelopeFactoryParserPoolCleanUpTest extends ClassLoaderPreMortemCleanUpTestBase<SAAJEnvelopeFactoryParserPoolCleanUp> {
 
-	@Override
+  @Override
   protected void triggerLeak() throws Exception {
     final ClassLoaderLeakPreventor preventor = getClassLoaderLeakPreventor();
 
@@ -27,7 +27,7 @@ public class SAAJEnvelopeFactoryParserPoolCleanUpTest extends ClassLoaderPreMort
 
     Class<?> envelopeFactoryClass = preventor.findClass("com.sun.xml.internal.messaging.saaj.soap.EnvelopeFactory");
     if (envelopeFactoryClass == null) {
-      // We are running JDK 11, so the SAAJ APIs are not available in the JDK anymore, so use the maven dependency
+      // Try the package for the maven dependency if the internal one is not available
       envelopeFactoryClass = preventor.findClass("com.sun.xml.messaging.saaj.soap.EnvelopeFactory");
     }
     
@@ -45,7 +45,7 @@ public class SAAJEnvelopeFactoryParserPoolCleanUpTest extends ClassLoaderPreMort
     putMethod.invoke(currentParserPool, saxParser);
   }
 
-	/*
+  /*
    * Create a dummy XMLErrorHandler to be loaded by the classloader that sould be garbage collected
    * Create using reflection, since the type is not accessible in newer Java Versions
    */

--- a/classloader-leak-prevention/classloader-leak-prevention-core/src/test/java/se/jiderhamn/classloader/leak/prevention/cleanup/SAAJEnvelopeFactoryParserPoolCleanUpTest.java
+++ b/classloader-leak-prevention/classloader-leak-prevention-core/src/test/java/se/jiderhamn/classloader/leak/prevention/cleanup/SAAJEnvelopeFactoryParserPoolCleanUpTest.java
@@ -1,11 +1,8 @@
 package se.jiderhamn.classloader.leak.prevention.cleanup;
 
+import java.lang.reflect.Method;
 import javax.xml.parsers.SAXParser;
 
-import com.sun.org.apache.xerces.internal.xni.XNIException;
-import com.sun.org.apache.xerces.internal.xni.parser.XMLParseException;
-import com.sun.xml.internal.messaging.saaj.soap.EnvelopeFactory;
-import com.sun.xml.internal.messaging.saaj.util.ParserPool;
 import se.jiderhamn.classloader.leak.prevention.ClassLoaderLeakPreventor;
 
 import static org.junit.Assert.assertNotNull;
@@ -16,7 +13,7 @@ import static org.junit.Assert.assertNotNull;
  */
 public class SAAJEnvelopeFactoryParserPoolCleanUpTest extends ClassLoaderPreMortemCleanUpTestBase<SAAJEnvelopeFactoryParserPoolCleanUp> {
 
-  @Override
+	@Override
   protected void triggerLeak() throws Exception {
     final ClassLoaderLeakPreventor preventor = getClassLoaderLeakPreventor();
 
@@ -28,26 +25,45 @@ public class SAAJEnvelopeFactoryParserPoolCleanUpTest extends ClassLoaderPreMort
     }
     */
 
+    Class<?> envelopeFactoryClass = preventor.findClass("com.sun.xml.internal.messaging.saaj.soap.EnvelopeFactory");
+    if (envelopeFactoryClass == null) {
+      // We are running JDK 11, so the SAAJ APIs are not available in the JDK anymore, so use the maven dependency
+      envelopeFactoryClass = preventor.findClass("com.sun.xml.messaging.saaj.soap.EnvelopeFactory");
+    }
+    
     final Object /* com.sun.xml.internal.messaging.saaj.soap.ContextClassloaderLocal */
-            parserPool = preventor.getStaticFieldValue(EnvelopeFactory.class, "parserPool");
-    final ParserPool currentParserPool = (ParserPool) preventor.findMethod(parserPool.getClass().getSuperclass(), "get").invoke(parserPool);
+            parserPool = preventor.getStaticFieldValue(envelopeFactoryClass, "parserPool");
+    final Object currentParserPool = preventor.findMethod(parserPool.getClass().getSuperclass(), "get").invoke(parserPool);
     assertNotNull(currentParserPool);
 
-    final SAXParser saxParser = currentParserPool.get();
-    saxParser.setProperty("http://apache.org/xml/properties/internal/error-handler", 
-        new CustomErrorHandler()); // Loaded by protected classloader
-    currentParserPool.put(saxParser);
+    final Method getMethod = preventor.findMethod(currentParserPool.getClass(), "get");
+    final SAXParser saxParser = (SAXParser) getMethod.invoke(currentParserPool);
+    
+    saxParser.setProperty("http://apache.org/xml/properties/internal/error-handler", getCustomErrorHandlerInstance(preventor));
+    
+    final Method putMethod = preventor.findMethod(currentParserPool.getClass(), "put", SAXParser.class);
+    putMethod.invoke(currentParserPool, saxParser);
   }
 
-  /** Dummy XMLErrorHandler loaded by the class loader that should be garbage collected*/
-  public static class CustomErrorHandler implements com.sun.org.apache.xerces.internal.xni.parser.XMLErrorHandler {
-    @Override
-    public void warning(String domain, String key, XMLParseException exception) throws XNIException { }
+	/*
+   * Create a dummy XMLErrorHandler to be loaded by the classloader that sould be garbage collected
+   * Create using reflection, since the type is not accessible in newer Java Versions
+   */
+  public Object getCustomErrorHandlerInstance(final ClassLoaderLeakPreventor preventor) {
+    final Class<?> errorHandlerClass = preventor.findClass("com.sun.org.apache.xerces.internal.xni.parser.XMLErrorHandler");
+   
+    Object instance = java.lang.reflect.Proxy.newProxyInstance(
+        this.getClass().getClassLoader(),
+        new java.lang.Class[] { errorHandlerClass },
+        new java.lang.reflect.InvocationHandler() {
 
-    @Override
-    public void error(String domain, String key, XMLParseException exception) throws XNIException { }
-
-    @Override
-    public void fatalError(String domain, String key, XMLParseException exception) throws XNIException { }
+        @Override
+        public Object invoke(Object proxy, java.lang.reflect.Method method, Object[] args) throws java.lang.Throwable {
+          // Can be empty since we don't really want to use the handler  
+          return null;
+        }
+    });
+    
+    return errorHandlerClass.cast(instance);
   }
 }


### PR DESCRIPTION
Hello @mjiderhamn,

since the first PR I've opened for Java 11 compatibility (#87) looks really cluttered, with multiple commits to the same file that sometimes revert each other, I'm splitting the changes into smaller PRs.

To fix the `SAAJEnvelopeFactoryParserPoolCleanUp` we have to change 2 things. First, we have to use reflection to obtain the parser pool and to create a custom error handler, since the necessary classes are not accessible anymore with Java 11. Second, some neccessary classes have been removed from the JDK with Java 11, so we use a maven dependency if the internal classes can not be found.