### PR TITLE
Clean up static field "configuration" in javax.security.auth.login.Configuration

### DIFF
--- a/classloader-leak-prevention/classloader-leak-prevention-core/src/main/java/se/jiderhamn/classloader/leak/prevention/cleanup/JavaxSecurityAuthLoginConfigurationCleanUp.java
+++ b/classloader-leak-prevention/classloader-leak-prevention-core/src/main/java/se/jiderhamn/classloader/leak/prevention/cleanup/JavaxSecurityAuthLoginConfigurationCleanUp.java
@@ -1,0 +1,20 @@
+package se.jiderhamn.classloader.leak.prevention.cleanup;
+
+import javax.security.auth.login.Configuration;
+
+import se.jiderhamn.classloader.leak.prevention.ClassLoaderLeakPreventor;
+import se.jiderhamn.classloader.leak.prevention.ClassLoaderPreMortemCleanUp;
+
+/**
+ * Cleanup for removing custom {@link javax.security.auth.login.Configuration}s loaded within the protected class loader.
+ * @author Nikos Epping
+ */
+public class JavaxSecurityAuthLoginConfigurationCleanUp implements ClassLoaderPreMortemCleanUp {
+
+  @Override
+  public void cleanUp(ClassLoaderLeakPreventor preventor) {
+    if (preventor.isLoadedInClassLoader(Configuration.getConfiguration())) {
+      Configuration.setConfiguration(null);
+    }
+  }
+}

--- a/classloader-leak-prevention/classloader-leak-prevention-core/src/test/java/se/jiderhamn/classloader/leak/prevention/cleanup/JavaxSecurityAuthLoginConfigurationCleanUpTest.java
+++ b/classloader-leak-prevention/classloader-leak-prevention-core/src/test/java/se/jiderhamn/classloader/leak/prevention/cleanup/JavaxSecurityAuthLoginConfigurationCleanUpTest.java
@@ -1,0 +1,24 @@
+package se.jiderhamn.classloader.leak.prevention.cleanup;
+
+import javax.security.auth.login.AppConfigurationEntry;
+import javax.security.auth.login.Configuration;
+
+/**
+ * Test case for {@link JavaxSecurityAuthLoginConfigurationCleanUp}
+ * @author Nikos Epping
+ */
+public class JavaxSecurityAuthLoginConfigurationCleanUpTest
+    extends ClassLoaderPreMortemCleanUpTestBase<JavaxSecurityAuthLoginConfigurationCleanUp> {
+
+  @Override
+  protected void triggerLeak() throws Exception {
+    Configuration.setConfiguration(new MockConfiguration());
+  }
+
+  private class MockConfiguration extends Configuration {
+    @Override
+    public AppConfigurationEntry[] getAppConfigurationEntry(String name) {
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
Hey there!

When testing some features from Spring-Kafka, we noticed that setting the property `spring.kafka.jaas.enabled=true` causes our webapp to leak. After some digging I found that Spring sets a Configuration [like this](https://github.com/spring-projects/spring-kafka/blob/47397fcc15a491ca0d13cfbc47c68448dbfbbc01/spring-kafka/src/main/java/org/springframework/kafka/security/jaas/KafkaJaasLoginModuleInitializer.java#L146): 
```
Configuration.setConfiguration(new InternalConfiguration(configurationEntries));
``` 
but never nulls that field, so the class `InternalConfiguration` will never be GC'ed.
To clean this up, we can just set the configuration to null, if it is loaded by the protected classloader.

By the way, is there any chance you could publish a new release of this library anytime soon, so we can use an official release to clean up leaks with Java 11?
