### PR TITLE
Fix Open Source Geospatial Foundation Repository url

### DIFF
--- a/classloader-leak-prevention/pom.xml
+++ b/classloader-leak-prevention/pom.xml
@@ -59,7 +59,7 @@
     <repository>
       <id>osgeo</id>
       <name>Open Source Geospatial Foundation Repository</name>
-      <url>http://download.osgeo.org/webdav/geotools/</url>
+      <url>https://repo.osgeo.org/repository/release/</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
The current repository url is `http://download.osgeo.org/webdav/geotools/`.
This is problematic because:
- Maven does not support non https url anymore
- the url does not resolve artifacts

The new url was found at https://docs.geotools.org/latest/userguide/tutorial/quickstart/maven.html