### PR TITLE
java.beans.Introspector leaks again with JDK 9 to JDK 15 ( fixes #123 )

### DIFF
--- a/classloader-leak-prevention/classloader-leak-prevention-core/pom.xml
+++ b/classloader-leak-prevention/classloader-leak-prevention-core/pom.xml
@@ -188,4 +188,25 @@
      </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>surefire-java9orhigher</id>
+        <activation>
+          <jdk>(9,)</jdk>
+        </activation>
+        <build>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <version>2.22.2</version>
+              <configuration>
+                <argLine>--add-opens java.desktop/com.sun.beans.introspect=ALL-UNNAMED</argLine>
+              </configuration>
+            </plugin>
+          </plugins>
+        </build>
+    </profile>
+  </profiles>
 </project>

--- a/classloader-leak-prevention/classloader-leak-prevention-core/pom.xml
+++ b/classloader-leak-prevention/classloader-leak-prevention-core/pom.xml
@@ -188,25 +188,4 @@
      </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>surefire-java9orhigher</id>
-        <activation>
-          <jdk>(9,)</jdk>
-        </activation>
-        <build>
-          <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-surefire-plugin</artifactId>
-              <version>2.22.2</version>
-              <configuration>
-                <argLine>--add-opens java.desktop/com.sun.beans.introspect=ALL-UNNAMED</argLine>
-              </configuration>
-            </plugin>
-          </plugins>
-        </build>
-    </profile>
-  </profiles>
 </project>

--- a/classloader-leak-prevention/classloader-leak-prevention-core/src/main/java/se/jiderhamn/classloader/leak/prevention/cleanup/BeanIntrospectorCleanUp.java
+++ b/classloader-leak-prevention/classloader-leak-prevention-core/src/main/java/se/jiderhamn/classloader/leak/prevention/cleanup/BeanIntrospectorCleanUp.java
@@ -28,13 +28,19 @@ public class BeanIntrospectorCleanUp implements ClassLoaderPreMortemCleanUp {
   private void clearClassInfoCache(ClassLoaderLeakPreventor preventor) {
       try {
           final Class<?> classInfoClass = preventor.findClass("com.sun.beans.introspect.ClassInfo");
-          if (classInfoClass == null) { return; }
+          if (classInfoClass == null) {
+            return;
+          }
 
           Field cacheField = preventor.findField(classInfoClass, "CACHE");
-          if (cacheField == null) { return; } // Either pre-JDK9 or exception occurred (should have been logged as warn at this point)
+          if (cacheField == null) {
+            return;  // Either pre-JDK9 or exception occurred (should have been logged as warn at this point)
+          }
 
           Object cacheInstance = cacheField.get(null);
-          if (cacheInstance == null) { return; }
+          if (cacheInstance == null) {
+            return;
+          }
           Method clearMethod = cacheInstance.getClass().getSuperclass().getDeclaredMethod("clear");
           clearMethod.invoke(cacheInstance);
       }

--- a/classloader-leak-prevention/classloader-leak-prevention-core/src/main/java/se/jiderhamn/classloader/leak/prevention/cleanup/BeanIntrospectorCleanUp.java
+++ b/classloader-leak-prevention/classloader-leak-prevention-core/src/main/java/se/jiderhamn/classloader/leak/prevention/cleanup/BeanIntrospectorCleanUp.java
@@ -1,5 +1,8 @@
 package se.jiderhamn.classloader.leak.prevention.cleanup;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
 import se.jiderhamn.classloader.leak.prevention.ClassLoaderLeakPreventor;
 import se.jiderhamn.classloader.leak.prevention.ClassLoaderPreMortemCleanUp;
 
@@ -11,5 +14,33 @@ public class BeanIntrospectorCleanUp implements ClassLoaderPreMortemCleanUp {
   @Override
   public void cleanUp(ClassLoaderLeakPreventor preventor) {
     java.beans.Introspector.flushCaches(); // Clear cache of strong references
+    clearClassInfoCache(preventor);
   }
+
+  /**
+   * Clears the BeanInfo SoftReference-based cache introduced in JDK 9
+   *
+   * References:
+   * * Clear explanation of the root cause: https://bugs.openjdk.java.net/browse/JDK-8207331
+   * * Issue which triggered the JDK fix: https://bugs.openjdk.java.net/browse/JDK-8231454
+   * * Fix commit (JDK16+ only as of now): https://github.com/openjdk/jdk/commit/2ee2b4ae
+   */
+  private void clearClassInfoCache(ClassLoaderLeakPreventor preventor) {
+      try {
+          final Class<?> classInfoClass = preventor.findClass("com.sun.beans.introspect.ClassInfo");
+          if (classInfoClass == null) { return; }
+
+          Field cacheField = preventor.findField(classInfoClass, "CACHE");
+          if (cacheField == null) { return; } // Either pre-JDK9 or exception occurred (should have been logged as warn at this point)
+
+          Object cacheInstance = cacheField.get(null);
+          if (cacheInstance == null) { return; }
+          Method clearMethod = cacheInstance.getClass().getSuperclass().getDeclaredMethod("clear");
+          clearMethod.invoke(cacheInstance);
+      }
+      catch (Exception e) {
+          preventor.warn(e);
+      }
+  }
+
 }

--- a/classloader-leak-prevention/classloader-leak-prevention-core/src/test/java/se/jiderhamn/classloader/leak/prevention/cleanup/BeanIntrospectorCleanUpTest.java
+++ b/classloader-leak-prevention/classloader-leak-prevention-core/src/test/java/se/jiderhamn/classloader/leak/prevention/cleanup/BeanIntrospectorCleanUpTest.java
@@ -1,0 +1,23 @@
+package se.jiderhamn.classloader.leak.prevention.cleanup;
+
+import java.beans.Introspector;
+
+public class BeanIntrospectorCleanUpTest extends ClassLoaderPreMortemCleanUpTestBase<BeanIntrospectorCleanUp> {
+
+    @Override
+    protected void triggerLeak() throws Exception {
+        Introspector.getBeanInfo(Bean.class);
+    }
+
+    protected class Bean {
+        private int dummyField;
+
+        public int getDummyField() {
+            return dummyField;
+        }
+
+        public void setDummyField(int dummyField) {
+            this.dummyField = dummyField;
+        }
+    }
+}

--- a/classloader-leak-prevention/classloader-leak-prevention-core/src/test/java/se/jiderhamn/classloader/leak/prevention/cleanup/BeanIntrospectorCleanUpTest.java
+++ b/classloader-leak-prevention/classloader-leak-prevention-core/src/test/java/se/jiderhamn/classloader/leak/prevention/cleanup/BeanIntrospectorCleanUpTest.java
@@ -2,6 +2,9 @@ package se.jiderhamn.classloader.leak.prevention.cleanup;
 
 import java.beans.Introspector;
 
+/**
+ * Test case for {@link BeanIntrospectorCleanUp}
+ */
 public class BeanIntrospectorCleanUpTest extends ClassLoaderPreMortemCleanUpTestBase<BeanIntrospectorCleanUp> {
 
     @Override


### PR DESCRIPTION
Changes:
* Added unit test for `BeanIntrospectorCleanUp`
* Augmented `BeanIntrospectorCleanUp` with introspection-based retrieval of the added cache and clear up
* Added pom surefire plugin configuration conditioned on JDK version (JDK9+ requires a `--add-opens` for this reflection magic to work, JDK8- fails to start with such an option)