### PR TITLE
Add java.io.ObjectStreamClass leak cleanup #125

### DIFF
--- a/classloader-leak-prevention/classloader-leak-prevention-core/src/main/java/se/jiderhamn/classloader/leak/prevention/ClassLoaderLeakPreventorFactory.java
+++ b/classloader-leak-prevention/classloader-leak-prevention-core/src/main/java/se/jiderhamn/classloader/leak/prevention/ClassLoaderLeakPreventorFactory.java
@@ -87,6 +87,7 @@ public class ClassLoaderLeakPreventorFactory {
     this.addPreInitiator(new OracleJdbcThreadInitiator());
 
     this.addCleanUp(new BeanIntrospectorCleanUp());
+    this.addCleanUp(new ObjectStreamClassCleanup());
     
     // Apache Commons Pool can leave unfinished threads. Anything specific we can do?
     this.addCleanUp(new BeanELResolverCleanUp());

--- a/classloader-leak-prevention/classloader-leak-prevention-core/src/main/java/se/jiderhamn/classloader/leak/prevention/cleanup/ObjectStreamClassCleanup.java
+++ b/classloader-leak-prevention/classloader-leak-prevention-core/src/main/java/se/jiderhamn/classloader/leak/prevention/cleanup/ObjectStreamClassCleanup.java
@@ -1,0 +1,37 @@
+package se.jiderhamn.classloader.leak.prevention.cleanup;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import se.jiderhamn.classloader.leak.prevention.ClassLoaderLeakPreventor;
+import se.jiderhamn.classloader.leak.prevention.ClassLoaderPreMortemCleanUp;
+
+/**
+ * Clean up for the static caches of {@link java.io.ObjectStreamClass}
+ */
+public class ObjectStreamClassCleanup implements ClassLoaderPreMortemCleanUp {
+
+    @Override
+    public void cleanUp(ClassLoaderLeakPreventor preventor) {
+        try {
+            final Class<?> cacheClass = preventor.findClass("java.io.ObjectStreamClass$Caches");
+            if (cacheClass == null) { return; }
+
+            Object localDescsCache = preventor.getStaticFieldValue(cacheClass, "localDescs");
+            clearIfConcurrentHashMap(localDescsCache, preventor);
+
+            Object reflectorsCache = preventor.getStaticFieldValue(cacheClass, "reflectors");
+            clearIfConcurrentHashMap(reflectorsCache, preventor);
+        }
+        catch (Exception e) {
+            preventor.error(e);
+        }
+    }
+
+    protected void clearIfConcurrentHashMap(Object object, ClassLoaderLeakPreventor preventor) {
+        if (!(object instanceof ConcurrentHashMap)) { return; }
+        ConcurrentHashMap<?,?> map = (ConcurrentHashMap<?,?>) object;
+        int nbOfEntries=map.size();
+        map.clear();
+        preventor.info("Detected and fixed leak situation for java.io.ObjectStreamClass ("+nbOfEntries+" entries were flushed).");
+    }
+}

--- a/classloader-leak-prevention/classloader-leak-prevention-core/src/test/java/se/jiderhamn/classloader/leak/prevention/cleanup/ObjectStreamClassCleanupTest.java
+++ b/classloader-leak-prevention/classloader-leak-prevention-core/src/test/java/se/jiderhamn/classloader/leak/prevention/cleanup/ObjectStreamClassCleanupTest.java
@@ -1,0 +1,22 @@
+package se.jiderhamn.classloader.leak.prevention.cleanup;
+
+import java.io.ObjectStreamClass;
+import java.io.Serializable;
+
+/**
+ * Test cases for {@link ObjectStreamClassCleanup}
+ */
+public class ObjectStreamClassCleanupTest extends ClassLoaderPreMortemCleanUpTestBase<ObjectStreamClassCleanup> {
+
+    @Override
+    protected void triggerLeak() throws Exception {
+        ObjectStreamClass.lookup(SerializableEntity.class);
+    }
+
+    protected final class SerializableEntity implements Serializable {
+
+        private static final long serialVersionUID = 1L;
+
+        public int value;
+    }
+}


### PR DESCRIPTION
This implementation deals with the leak detected in #125 by adding a new cleanup task (registered into `ClassLoaderLeakPreventorFactory`).

Related unit test added.