### PR TITLE
Add capability to build and test with JDK up to version 17 (fixed #127)

### DIFF
--- a/classloader-leak-prevention/classloader-leak-prevention-core/pom.xml
+++ b/classloader-leak-prevention/classloader-leak-prevention-core/pom.xml
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>se.jiderhamn</groupId>
       <artifactId>classloader-leak-test-framework</artifactId>
-      <version>1.1.1</version>
+      <version>1.1.2-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
     <!-- Required by some of the tested APIs --> 
@@ -87,7 +87,7 @@
     <dependency>
       <groupId>org.geotools</groupId>
       <artifactId>gt-metadata</artifactId>
-      <version>2.6.2</version>
+      <version>26.1.06</version>
       <scope>test</scope>
     </dependency>
     <!-- Test leak in JSF api -->

--- a/classloader-leak-prevention/classloader-leak-prevention-core/src/test/java/se/jiderhamn/classloader/leak/prevention/cleanup/JavaUtilLoggingLevelCleanUpTest.java
+++ b/classloader-leak-prevention/classloader-leak-prevention-core/src/test/java/se/jiderhamn/classloader/leak/prevention/cleanup/JavaUtilLoggingLevelCleanUpTest.java
@@ -1,5 +1,9 @@
 package se.jiderhamn.classloader.leak.prevention.cleanup;
 
+import org.junit.Assume;
+
+import se.jiderhamn.classloader.leak.prevention.support.JavaVersion;
+
 /**
  * Test cases for {@link JavaUtilLoggingLevelCleanUp}
  * @author Mattias Jiderhamn
@@ -7,6 +11,9 @@ package se.jiderhamn.classloader.leak.prevention.cleanup;
 public class JavaUtilLoggingLevelCleanUpTest extends ClassLoaderPreMortemCleanUpTestBase<JavaUtilLoggingLevelCleanUp> {
   @Override
   protected void triggerLeak() throws Exception {
+      // Leak does not occur any more with JDK11+
+      Assume.assumeTrue(JavaVersion.IS_JAVA_10_OR_EARLIER);
+
     // TODO Log
     // Logger logger = Logger.getLogger(JavaUtilLoggingLevelCleanUpTest.class.getName());
     // logger.setLevel(

--- a/classloader-leak-prevention/classloader-leak-prevention-core/src/test/java/se/jiderhamn/classloader/leak/prevention/cleanup/ReplaceDOMNormalizerSerializerAbortExceptionCleanUpTest.java
+++ b/classloader-leak-prevention/classloader-leak-prevention-core/src/test/java/se/jiderhamn/classloader/leak/prevention/cleanup/ReplaceDOMNormalizerSerializerAbortExceptionCleanUpTest.java
@@ -3,6 +3,9 @@ package se.jiderhamn.classloader.leak.prevention.cleanup;
 import se.jiderhamn.classloader.leak.prevention.ClassLoaderPreMortemCleanUp;
 import se.jiderhamn.classloader.leak.prevention.ReplaceDOMNormalizerSerializerAbortException;
 import se.jiderhamn.classloader.leak.prevention.preinit.ReplaceDOMNormalizerSerializerAbortExceptionInitiatorTest;
+import se.jiderhamn.classloader.leak.prevention.support.JavaVersion;
+
+import org.junit.Assume;
 
 /**
  * Test cases for {@link ReplaceDOMNormalizerSerializerAbortException} when used as {@link ClassLoaderPreMortemCleanUp}
@@ -13,4 +16,12 @@ public class ReplaceDOMNormalizerSerializerAbortExceptionCleanUpTest extends Cla
   public void triggerLeak() throws Exception {
     ReplaceDOMNormalizerSerializerAbortExceptionInitiatorTest.triggerLeak();
   }
+
+    @Override
+    public void triggerLeakWithoutCleanup() throws Exception {
+        // Leak does not occur any more with JDK8+
+        Assume.assumeTrue(JavaVersion.IS_JAVA_1_6 || JavaVersion.IS_JAVA_1_7);
+        super.triggerLeakWithoutCleanup();
+    }
+
 }

--- a/classloader-leak-prevention/classloader-leak-prevention-core/src/test/java/se/jiderhamn/classloader/leak/prevention/cleanup/X509TrustManagerImplUnparseableExtensionCleanUpTest.java
+++ b/classloader-leak-prevention/classloader-leak-prevention-core/src/test/java/se/jiderhamn/classloader/leak/prevention/cleanup/X509TrustManagerImplUnparseableExtensionCleanUpTest.java
@@ -3,6 +3,10 @@ package se.jiderhamn.classloader.leak.prevention.cleanup;
 import java.io.File;
 import javax.net.ssl.SSLContext;
 
+import org.junit.Assume;
+
+import se.jiderhamn.classloader.leak.prevention.support.JavaVersion;
+
 /**
  * Test case for {@link X509TrustManagerImplUnparseableExtensionCleanUp}
  * @author Mattias Jiderhamn
@@ -14,4 +18,12 @@ public class X509TrustManagerImplUnparseableExtensionCleanUpTest extends ClassLo
     System.setProperty("javax.net.ssl.trustStore", keystore.getAbsolutePath());
     SSLContext.getDefault();
   }
+
+    @Override
+    public void triggerLeakWithoutCleanup() throws Exception {
+        // Leak does not occur any more with JDK17+ (and maybe some versions above JDK11 - not tested) 
+        Assume.assumeTrue(JavaVersion.IS_JAVA_16_OR_EARLIER);
+        super.triggerLeakWithoutCleanup();
+    }
+
 }

--- a/classloader-leak-prevention/classloader-leak-prevention-core/src/test/java/se/jiderhamn/classloader/leak/prevention/preinit/LdapPoolManagerInitiatorTest.java
+++ b/classloader-leak-prevention/classloader-leak-prevention-core/src/test/java/se/jiderhamn/classloader/leak/prevention/preinit/LdapPoolManagerInitiatorTest.java
@@ -1,6 +1,9 @@
 package se.jiderhamn.classloader.leak.prevention.preinit;
 
+import org.junit.Assume;
 import org.junit.Before;
+
+import se.jiderhamn.classloader.leak.prevention.support.JavaVersion;
 
 /**
  * Test cases for {@link LdapPoolManagerInitiator}
@@ -11,4 +14,11 @@ public class LdapPoolManagerInitiatorTest extends PreClassLoaderInitiatorTestBas
   public void setSystemProperty() {
     System.setProperty("com.sun.jndi.ldap.connect.pool.timeout", "1"); // Required to trigger leak
   }
+
+    @Override
+    public void firstShouldLeak() throws Exception {
+        // Leak does not occur any more with JDK8+
+        Assume.assumeTrue(JavaVersion.IS_JAVA_1_6 || JavaVersion.IS_JAVA_1_7);
+        super.firstShouldLeak();
+    }
 }

--- a/classloader-leak-prevention/classloader-leak-prevention-core/src/test/java/se/jiderhamn/classloader/leak/prevention/preinit/SunGCInitiatorTest.java
+++ b/classloader-leak-prevention/classloader-leak-prevention-core/src/test/java/se/jiderhamn/classloader/leak/prevention/preinit/SunGCInitiatorTest.java
@@ -1,8 +1,20 @@
 package se.jiderhamn.classloader.leak.prevention.preinit;
 
+import org.junit.Assume;
+
+import se.jiderhamn.classloader.leak.prevention.support.JavaVersion;
+
 /**
  * Test cases for {@link SunGCInitiator}
  * @author Mattias Jiderhamn
  */
 public class SunGCInitiatorTest extends PreClassLoaderInitiatorTestBase<SunGCInitiator> {
+
+    @Override
+    public void firstShouldLeak() throws Exception {
+        // Leak does not occur any more with JDK11+ (and maybe 9 and 10 - not tested)
+        Assume.assumeTrue(JavaVersion.IS_JAVA_10_OR_EARLIER);
+        super.firstShouldLeak();
+    }
+
 }

--- a/classloader-leak-prevention/classloader-leak-prevention-core/src/test/java/se/jiderhamn/classloader/leak/prevention/support/JavaVersion.java
+++ b/classloader-leak-prevention/classloader-leak-prevention-core/src/test/java/se/jiderhamn/classloader/leak/prevention/support/JavaVersion.java
@@ -1,0 +1,99 @@
+package se.jiderhamn.classloader.leak.prevention.support;
+
+/**
+ * A few helper functions to use as a condition for JDK-dependant unit tests.
+ */
+public class JavaVersion {
+
+    public static final String JAVA_SPECIFICATION_VERSION = System.getProperty("java.specification.version");
+
+    /**
+     * Is {@code true} if this is Java version 1.6 (also 1.6.x versions).
+     */
+    public static final boolean IS_JAVA_1_6 = isJavaVersionMatch("1.6");
+
+    /**
+     * Is {@code true} if this is Java version 1.7 (also 1.7.x versions).
+     */
+    public static final boolean IS_JAVA_1_7 = isJavaVersionMatch("1.7");
+
+    /**
+     * Is {@code true} if this is Java version 1.8 (also 1.8.x versions).
+     */
+    public static final boolean IS_JAVA_1_8 = isJavaVersionMatch("1.8");
+
+    /**
+     * Is {@code true} if this is Java version 1.8 or earlier (includes 1.8.x versions).
+     */
+    public static final boolean IS_JAVA_1_8_OR_EARLIER = JavaVersion.IS_JAVA_1_6 || JavaVersion.IS_JAVA_1_7 || JavaVersion.IS_JAVA_1_8;
+
+    /**
+     * Is {@code true} if this is Java version 9 (also 9.x versions).
+     */
+    public static final boolean IS_JAVA_9 = isJavaVersionMatch("9");
+
+    /**
+     * Is {@code true} if this is Java version 10 (also 10.x versions).
+     */
+    public static final boolean IS_JAVA_10 = isJavaVersionMatch("10");
+
+    /**
+     * Is {@code true} if this is Java version 10 or earlier (includes 10.x versions).
+     */
+    public static final boolean IS_JAVA_10_OR_EARLIER = IS_JAVA_1_8_OR_EARLIER || JavaVersion.IS_JAVA_9 || JavaVersion.IS_JAVA_10;
+
+    /**
+     * Is {@code true} if this is Java version 11 (also 11.x versions).
+     */
+    public static final boolean IS_JAVA_11 = isJavaVersionMatch("11");
+
+    /**
+     * Is {@code true} if this is Java version 12 (also 12.x versions).
+     */
+    public static final boolean IS_JAVA_12 = isJavaVersionMatch("12");
+
+    /**
+     * Is {@code true} if this is Java version 13 (also 13.x versions).
+     */
+    public static final boolean IS_JAVA_13 = isJavaVersionMatch("13");
+
+    /**
+     * Is {@code true} if this is Java version 14 (also 14.x versions).
+     */
+    public static final boolean IS_JAVA_14 = isJavaVersionMatch("14");
+
+    /**
+     * Is {@code true} if this is Java version 15 (also 15.x versions).
+     */
+    public static final boolean IS_JAVA_15 = isJavaVersionMatch("15");
+
+    /**
+     * Is {@code true} if this is Java version 16 (also 16.x versions).
+     */
+    public static final boolean IS_JAVA_16 = isJavaVersionMatch("16");
+
+    /**
+     * Is {@code true} if this is Java version 16 or earlier (includes 16.x versions).
+     */
+    public static final boolean IS_JAVA_16_OR_EARLIER =
+            IS_JAVA_10_OR_EARLIER
+            || JavaVersion.IS_JAVA_11
+            || JavaVersion.IS_JAVA_12
+            || JavaVersion.IS_JAVA_13
+            || JavaVersion.IS_JAVA_14
+            || JavaVersion.IS_JAVA_15
+            || JavaVersion.IS_JAVA_16;
+
+    /**
+     * Is {@code true} if this is Java version 17 (also 17.x versions).
+     */
+    public static final boolean IS_JAVA_17 = isJavaVersionMatch("17");
+
+    static boolean isJavaVersionMatch(final String versionPrefix) {
+        String version = JAVA_SPECIFICATION_VERSION;
+        if (version == null) {
+            return false;
+        }
+        return version.startsWith(versionPrefix);
+    }
+}

--- a/classloader-leak-prevention/pom.xml
+++ b/classloader-leak-prevention/pom.xml
@@ -104,8 +104,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.6.1</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
           <fork>true</fork>
           <!-- Allow compiling against com.sun.xml.internal classes -->
           <testCompilerArgument>-XDignore.symbol.file</testCompilerArgument>
@@ -125,6 +125,41 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>surefire-java9orhigher</id>
+        <activation>
+          <jdk>(9,)</jdk>
+        </activation>
+        <build>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <version>2.22.2</version>
+              <configuration>
+                <argLine>
+                   --add-opens java.base/java.lang=ALL-UNNAMED
+                   --add-opens java.base/java.net=ALL-UNNAMED
+                   --add-opens java.base/java.util=ALL-UNNAMED
+                   --add-opens java.base/java.security=ALL-UNNAMED
+                   --add-opens java.base/javax.crypto=ALL-UNNAMED
+                   --add-opens java.base/sun.reflect.misc=ALL-UNNAMED
+                   --add-opens java.base/sun.security.action=ALL-UNNAMED
+                   --add-opens java.desktop/java.beans=ALL-UNNAMED
+                   --add-opens java.desktop/javax.imageio.spi=ALL-UNNAMED
+                   --add-opens java.desktop/sun.java2d.opengl=ALL-UNNAMED
+                   --add-opens java.desktop/sun.awt=ALL-UNNAMED
+                   --add-opens java.desktop/sun.swing=ALL-UNNAMED
+                   --add-opens java.desktop/sun.lwawt.macosx=ALL-UNNAMED
+                   --add-opens java.rmi/sun.rmi.transport=ALL-UNNAMED
+                   --add-opens java.management/sun.management=ALL-UNNAMED
+                   --add-opens java.management/com.sun.jmx.interceptor=ALL-UNNAMED
+                </argLine>
+              </configuration>
+            </plugin>
+          </plugins>
+        </build>
+    </profile>
     <profile>
       <id>release</id>
       <build>

--- a/classloader-leak-test-framework/pom.xml
+++ b/classloader-leak-test-framework/pom.xml
@@ -44,8 +44,8 @@
   </developers>   
 
   <properties>
-    <maven.compiler.source>1.6</maven.compiler.source>
-    <maven.compiler.target>1.6</maven.compiler.target>
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
     <!-- Disable strict JavaDoc checking, as per http://blog.joda.org/2014/02/turning-off-doclint-in-jdk-8-javadoc.html -->
     <additionalparam>-Xdoclint:none</additionalparam>
   </properties>
@@ -104,6 +104,31 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>surefire-java9orhigher</id>
+        <activation>
+          <jdk>(9,)</jdk>
+        </activation>
+        <build>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-surefire-plugin</artifactId>
+              <version>2.22.2</version>
+              <configuration>
+                <argLine>
+                   --add-opens java.base/sun.reflect.misc=ALL-UNNAMED
+                   --add-opens java.base/sun.reflect.misc=ALL-UNNAMED
+                   --add-opens java.base/sun.security.action=ALL-UNNAMED
+                   --add-opens java.desktop/sun.awt=ALL-UNNAMED
+                   --add-opens java.desktop/sun.swing=ALL-UNNAMED
+                   --add-opens java.desktop/sun.lwawt.macosx=ALL-UNNAMED
+                </argLine>
+              </configuration>
+            </plugin>
+          </plugins>
+        </build>
+    </profile>
     <profile>
       <id>release</id>
       <build>


### PR DESCRIPTION
This provides the capability to build and test against recent JDK versions (tested up with JDK 17).

* JDK source and target are now set to 1.7 as this is the minimal version supported by JDK 17
* All appropriate `--add-opens` have been added using a maven profile with activation based on JDK version (9+) so that it still compiles with prior versions (JDK 7 and 8)
* Add support for `org.junit.Assume` in `classloader-leak-test-framework` to allow tests to be conditionally ignored based on JDK version
* Add JDK version conditions for tests which leak condition have been fixed in later versions

Note that dependency from `classloader-leak-prevention` onto `classloader-leak-test-framework` is left as `SNAPSHOT` in this PR since this requires releasing a new version (which is obviously not possible using a PR).
