### PR TITLE
Remove finalize from RedefiningClassLoader

### DIFF
--- a/classloader-leak-test-framework/src/main/java/se/jiderhamn/classloader/RedefiningClassLoader.java
+++ b/classloader-leak-test-framework/src/main/java/se/jiderhamn/classloader/RedefiningClassLoader.java
@@ -55,13 +55,6 @@ public class RedefiningClassLoader extends org.apache.bcel.util.ClassLoader {
   }
 
   @Override
-  protected void finalize() throws Throwable {
-    System.out.println(this + " is being finalized");
-    
-    // TODO: Report?
-  }
-
-  @Override
   public String toString() {
     return (name != null) ? (this.getClass().getName() + '[' + name + "]@" + Integer.toHexString(System.identityHashCode(this))) :  
         super.toString();


### PR DESCRIPTION
Object.finalize() is deprecated for removal, and having a non-trivial .finalize() makes it harder to garbage-collect RedefiningClassLoader.

Fixes https://github.com/mjiderhamn/classloader-leak-prevention/issues/138